### PR TITLE
Switch to export objects from shortcuts

### DIFF
--- a/packages/assets/src/index.ts
+++ b/packages/assets/src/index.ts
@@ -1,2 +1,2 @@
-export { cdnUrl } from './cdn';
-export { fontUrls } from './fonts';
+export * from './cdn';
+export * from './fonts';

--- a/packages/components/src/button/button.tsx
+++ b/packages/components/src/button/button.tsx
@@ -9,7 +9,7 @@ import { buttonDisabled } from './mixins';
 import { buttonModifiers, ButtonModifiers } from './modifiers';
 import { buttonMockStateClass, ButtonMockState } from './states';
 
-export type ButtonProps = {
+type ButtonProps = {
   href?: string;
   modifier: ButtonModifiers;
   disabled?: boolean;
@@ -50,7 +50,7 @@ const buttonSpaced = css({
 /**
  * Component
  */
-export const Button: React.SFC<ButtonProps> = props => {
+const Button: React.SFC<ButtonProps> = props => {
   const ButtonElement = !props.href ? 'button' : 'a';
 
   /**
@@ -77,3 +77,5 @@ export const Button: React.SFC<ButtonProps> = props => {
 Button.defaultProps = {
   modifier: 'primary',
 };
+
+export { Button, ButtonProps };

--- a/packages/components/src/button/index.ts
+++ b/packages/components/src/button/index.ts
@@ -1,1 +1,1 @@
-export { Button } from './button';
+export * from './button';

--- a/packages/components/src/button/mixins.ts
+++ b/packages/components/src/button/mixins.ts
@@ -8,7 +8,7 @@ import { spacing } from '@heathmont/sportsbet-utils';
  * Removes user-agent `:focus` styles and generates a box-shadow using the
  * color provided.
  */
-export const buttonShadow = (color: string) =>
+const buttonShadow = (color: string) =>
   css({
     outline: 'none',
     boxShadow: `0 0 ${spacing('default', 'px')} ${color}`,
@@ -28,7 +28,7 @@ type DisabledStyle = 'solid' | 'border';
 const colorDisabled = '#414f57';
 const colorDisabledText = '#677278';
 
-export const buttonDisabled = (key: DisabledStyle) => {
+const buttonDisabled = (key: DisabledStyle) => {
   const disabledBase = css({
     cursor: 'not-allowed',
   });
@@ -49,3 +49,5 @@ export const buttonDisabled = (key: DisabledStyle) => {
     '&:disabled, &[disabled]': [disabledBase, disabledVariants[key]],
   });
 };
+
+export { buttonShadow, buttonDisabled };

--- a/packages/components/src/button/modifiers.ts
+++ b/packages/components/src/button/modifiers.ts
@@ -3,11 +3,7 @@ import { colors, typography } from '@heathmont/sportsbet-tokens';
 import { buttonShadow, buttonDisabled } from './mixins';
 import { buttonActive, buttonFocus } from './states';
 
-export type ButtonModifiers =
-  | 'primary'
-  | 'secondary'
-  | 'optional'
-  | 'alternate';
+type ButtonModifiers = 'primary' | 'secondary' | 'optional' | 'alternate';
 
 /**
  * buttonModifiers
@@ -79,9 +75,11 @@ const alternate = css([
   }),
 ]);
 
-export const buttonModifiers = {
+const buttonModifiers = {
   primary,
   secondary,
   optional,
   alternate,
 };
+
+export { buttonModifiers, ButtonModifiers };

--- a/packages/components/src/button/states.ts
+++ b/packages/components/src/button/states.ts
@@ -1,4 +1,4 @@
-export type ButtonMockState = 'active' | 'focus';
+type ButtonMockState = 'active' | 'focus';
 
 /**
  * buttonMockStateClass
@@ -7,7 +7,7 @@ export type ButtonMockState = 'active' | 'focus';
  * traditional CSS `:state` selectors. This allows us to mock the appearance of
  * a button's state for documentation / purely stylistic purposes.
  */
-export const buttonMockStateClass = (state: ButtonMockState) =>
+const buttonMockStateClass = (state: ButtonMockState) =>
   ({
     active: 'is-active',
     focus: 'has-focus',
@@ -18,7 +18,7 @@ export const buttonMockStateClass = (state: ButtonMockState) =>
  *
  * Wraps styles with the appropriate "active"-style selectors.
  */
-export const buttonActive = (styles: object) => ({
+const buttonActive = (styles: object) => ({
   [`
     &.${buttonMockStateClass('active')},
     &.${buttonMockStateClass('focus')},
@@ -37,7 +37,7 @@ export const buttonActive = (styles: object) => ({
  *
  * Wraps styles with the appropriate "focus"-style selectors.
  */
-export const buttonFocus = (styles: object) => ({
+const buttonFocus = (styles: object) => ({
   [`
     &.${buttonMockStateClass('focus')},
     &:focus
@@ -45,3 +45,5 @@ export const buttonFocus = (styles: object) => ({
     ...styles,
   },
 });
+
+export { ButtonMockState, buttonMockStateClass, buttonActive, buttonFocus };

--- a/packages/components/src/card/balance.tsx
+++ b/packages/components/src/card/balance.tsx
@@ -7,14 +7,14 @@ import { colors } from '@heathmont/sportsbet-tokens';
 import { spacing } from '@heathmont/sportsbet-utils';
 jsx;
 
-export type Balance = {
+type Balance = {
   currency: string;
   value: number;
   unit: string;
   unitTitle?: string;
 };
 
-export type CardBalanceProps = {
+type CardBalanceProps = {
   from: Balance;
   to: Balance;
 };
@@ -45,7 +45,7 @@ const Text = styled.p({
 /**
  * Component
  */
-export const CardBalance: React.SFC<CardBalanceProps> = ({ from, to }) => {
+const CardBalance: React.SFC<CardBalanceProps> = ({ from, to }) => {
   return (
     <div>
       <Text>{from.currency}</Text>
@@ -64,3 +64,5 @@ export const CardBalance: React.SFC<CardBalanceProps> = ({ from, to }) => {
     </div>
   );
 };
+
+export { CardBalance, CardBalanceProps };

--- a/packages/components/src/card/card.tsx
+++ b/packages/components/src/card/card.tsx
@@ -6,7 +6,7 @@ import { border, colors } from '@heathmont/sportsbet-tokens';
 import { spacing } from '@heathmont/sportsbet-utils';
 import { cardGradient } from './utils';
 
-export type CardProps = {
+type CardProps = {
   template: 'front' | 'back' | 'outline';
   children: JSX.Element[] | JSX.Element;
   flex?: boolean;
@@ -51,7 +51,7 @@ const cardModifiers = {
 /**
  * Component
  */
-export const Card: React.SFC<CardProps> = ({ children, flex, template }) => {
+const Card: React.SFC<CardProps> = ({ children, flex, template }) => {
   const Card = styled('div')(
     cardBase,
     flex && cardFlex,
@@ -65,3 +65,5 @@ Card.defaultProps = {
   flex: false,
   template: 'front',
 };
+
+export { Card, CardProps };

--- a/packages/components/src/card/toggle.tsx
+++ b/packages/components/src/card/toggle.tsx
@@ -4,7 +4,7 @@ import { css, jsx } from '@emotion/core';
 import { spacing } from '@heathmont/sportsbet-utils';
 jsx;
 
-export type CardToggleProps = {
+type CardToggleProps = {
   back?: boolean;
 };
 
@@ -27,7 +27,7 @@ const cardToggle = css({
 /**
  * Component
  */
-export const CardToggle: React.SFC<CardToggleProps> = ({ back }) => {
+const CardToggle: React.SFC<CardToggleProps> = ({ back }) => {
   const icon = !back ? '⚙️' : '↩️';
 
   return <button css={cardToggle}>{icon}</button>;
@@ -36,3 +36,5 @@ export const CardToggle: React.SFC<CardToggleProps> = ({ back }) => {
 CardToggle.defaultProps = {
   back: false,
 };
+
+export { CardToggle, CardToggleProps };

--- a/packages/components/src/card/utils/index.ts
+++ b/packages/components/src/card/utils/index.ts
@@ -1,1 +1,1 @@
-export { cardGradient } from './gradient';
+export * from './gradient';

--- a/packages/components/src/heading/heading.tsx
+++ b/packages/components/src/heading/heading.tsx
@@ -4,13 +4,13 @@ import { jsx } from '@emotion/core';
 import { headingSizes, HeadingSizes } from './sizes';
 jsx;
 
-export type HeadingProps = {
+type HeadingProps = {
   size: HeadingSizes;
   element?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
   color?: string;
 };
 
-export const Heading: React.SFC<HeadingProps> = ({
+const Heading: React.SFC<HeadingProps> = ({
   element = 'p',
   size,
   color,
@@ -25,3 +25,5 @@ export const Heading: React.SFC<HeadingProps> = ({
 Heading.defaultProps = {
   color: 'inherit',
 };
+
+export { Heading, HeadingProps };

--- a/packages/components/src/heading/index.ts
+++ b/packages/components/src/heading/index.ts
@@ -1,1 +1,1 @@
-export { Heading } from './heading';
+export * from './heading';

--- a/packages/components/src/heading/sizes.tsx
+++ b/packages/components/src/heading/sizes.tsx
@@ -2,7 +2,7 @@ import { rem } from 'polished';
 import { css } from '@emotion/core';
 import { typography } from '@heathmont/sportsbet-tokens';
 
-export type HeadingSizes =
+type HeadingSizes =
   | 'alpha'
   | 'bravo'
   | 'charlie'
@@ -46,7 +46,7 @@ const foxtrot = css({
   lineHeight: rem(41),
 });
 
-export const headingSizes = {
+const headingSizes = {
   alpha,
   bravo,
   charlie,
@@ -54,3 +54,5 @@ export const headingSizes = {
   echo,
   foxtrot,
 };
+
+export { headingSizes, HeadingSizes };

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,2 +1,4 @@
+export * from './button';
 export * from './card';
-export { Button } from './button';
+export * from './heading';
+export * from './link';

--- a/packages/components/src/link/index.ts
+++ b/packages/components/src/link/index.ts
@@ -1,1 +1,1 @@
-export { Link } from './link';
+export * from './link';

--- a/packages/components/src/link/link.tsx
+++ b/packages/components/src/link/link.tsx
@@ -1,10 +1,10 @@
 /** @jsx jsx */
-import * as React from "react";
-import { css, jsx } from "@emotion/core";
-import { colors } from "@heathmont/sportsbet-tokens";
+import * as React from 'react';
+import { css, jsx } from '@emotion/core';
+import { colors } from '@heathmont/sportsbet-tokens';
 jsx;
 
-export type LinkProps = {
+type LinkProps = {
   href?: string;
   disabled?: boolean;
 };
@@ -14,35 +14,37 @@ export type LinkProps = {
  */
 const linkBase = css([
   {
-    display: "inline-block",
+    display: 'inline-block',
     margin: 0,
     padding: 0,
-    verticalAlign: "middle",
-    font: "inherit",
+    verticalAlign: 'middle',
+    font: 'inherit',
     color: colors.brand,
-    backgroundColor: "transparent",
+    backgroundColor: 'transparent',
     border: 0,
-    cursor: "pointer",
-    textDecoration: "none",
-    "&:hover, &:focus, &:active": {
-      color: colors.highlight
+    cursor: 'pointer',
+    textDecoration: 'none',
+    '&:hover, &:focus, &:active': {
+      color: colors.highlight,
     },
-    "&:disabled, &[disabled]": {
+    '&:disabled, &[disabled]': {
       color: colors.neutral[30],
-      cursor: "not-allowed"
-    }
-  }
+      cursor: 'not-allowed',
+    },
+  },
 ]);
 
 /**
  * Component
  */
-export const Link: React.SFC<LinkProps> = ({ href, ...props }) => {
-  const LinkElement = !href ? "button" : "a";
+const Link: React.SFC<LinkProps> = ({ href, ...props }) => {
+  const LinkElement = !href ? 'button' : 'a';
 
   return jsx(LinkElement, {
     href: href || undefined,
     css: linkBase,
-    ...props
+    ...props,
   });
 };
+
+export { Link, LinkProps };

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -1,6 +1,6 @@
-export { base, Base } from './base';
-export { border, Border } from './border';
-export { breakpoints, Breakpoints } from './breakpoints';
-export { colors, Colors } from './colors';
-export { spacing, Spacing } from './spacing';
-export { typography, FontWeight } from './typography';
+export * from './base';
+export * from './border';
+export * from './breakpoints';
+export * from './colors';
+export * from './spacing';
+export * from './typography';

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,2 +1,2 @@
-export { mq } from './mq';
-export { spacing } from './spacing';
+export * from './mq';
+export * from './spacing';


### PR DESCRIPTION
## Description

We're currently using `export const` or `export type` in a number of places

## Motivation and Context

* `export type` doesn't seem to actually work
* Tricky to determine what in a file is being exported, placing all exports in one `export { }` makes it easier to track

## How Has This Been Tested?

All tests pass, build passes.

## Screenshots

N/A

## Types of changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [x] I have read the [**contributing guidelines**][contributing].
- [x] My code follows the [code style][code-style] of this project.
- [x] My code meets the [A11Y Web Accessibility Checklist](https://a11yproject.com/checklist). If not, please add justification documentation.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[contributing]: https://github.com/coingaming/sportsbet-design/blob/master/CONTRIBUTING.md
[code-style]: https://github.com/coingaming/sportsbet-design/blob/master/CONTRIBUTING.md#code-style
