### PR TITLE
Enhance Live Code Previews

### DIFF
--- a/docs/src/components/code/index.tsx
+++ b/docs/src/components/code/index.tsx
@@ -47,13 +47,18 @@ const liveCodePreview = css({
   overflowY: 'scroll',
 });
 
+/* Ensures that we can use `css` props + not have to worry about wrapper divs */
+const transformCode = (src: any) =>
+  `/** @jsx jsx */<React.Fragment>${src}</React.Fragment>`;
+
 export const Code = ({ codeString, language, ...props }: CodeProps) =>
   props['react-live'] ? (
     <LiveProvider
       mountStylesheet={false}
       code={codeString}
       css={codeWrapper}
-      scope={{ ...Components, ...Utils, colors }}
+      scope={{ jsx, ...Components, ...Utils, colors }}
+      transformCode={transformCode}
     >
       <LivePreview css={liveCodePreview} />
       <div css={css({ overflowY: 'scroll' })}>

--- a/packages/components/src/button/README.mdx
+++ b/packages/components/src/button/README.mdx
@@ -16,20 +16,18 @@ import { PropsTable } from 'docs';
 To be used where the the button would be the main call to action on the page.
 
 ```jsx react-live
-<div>
-  <Button modifier="primary" spaced>
-    Default
-  </Button>
-  <Button modifier="primary" mockState="active" spaced>
-    Hover
-  </Button>
-  <Button modifier="primary" mockState="focus" spaced>
-    Focus
-  </Button>
-  <Button modifier="primary" disabled spaced>
-    Disabled
-  </Button>
-</div>
+<Button modifier="primary" spaced>
+  Default
+</Button>
+<Button modifier="primary" mockState="active" spaced>
+  Hover
+</Button>
+<Button modifier="primary" mockState="focus" spaced>
+  Focus
+</Button>
+<Button modifier="primary" disabled spaced>
+  Disabled
+</Button>
 ```
 
 ### Secondary
@@ -37,20 +35,18 @@ To be used where the the button would be the main call to action on the page.
 To be used where the the button would be alternative or secondary call to action.
 
 ```jsx react-live
-<div>
-  <Button modifier="secondary" spaced>
-    Default
-  </Button>
-  <Button modifier="secondary" mockState="active" spaced>
-    Hover
-  </Button>
-  <Button modifier="secondary" mockState="focus" spaced>
-    Focus
-  </Button>
-  <Button modifier="secondary" disabled spaced>
-    Disabled
-  </Button>
-</div>
+<Button modifier="secondary" spaced>
+  Default
+</Button>
+<Button modifier="secondary" mockState="active" spaced>
+  Hover
+</Button>
+<Button modifier="secondary" mockState="focus" spaced>
+  Focus
+</Button>
+<Button modifier="secondary" disabled spaced>
+  Disabled
+</Button>
 ```
 
 ### Optional
@@ -58,20 +54,18 @@ To be used where the the button would be alternative or secondary call to action
 To be used where the the button would be an optional call to action - meaning not prominant.
 
 ```jsx react-live
-<div>
-  <Button modifier="optional" spaced>
-    Default
-  </Button>
-  <Button modifier="optional" mockState="active" spaced>
-    Hover
-  </Button>
-  <Button modifier="optional" mockState="focus" spaced>
-    Focus
-  </Button>
-  <Button modifier="optional" disabled spaced>
-    Disabled
-  </Button>
-</div>
+<Button modifier="optional" spaced>
+  Default
+</Button>
+<Button modifier="optional" mockState="active" spaced>
+  Hover
+</Button>
+<Button modifier="optional" mockState="focus" spaced>
+  Focus
+</Button>
+<Button modifier="optional" disabled spaced>
+  Disabled
+</Button>
 ```
 
 ### Alternate
@@ -79,20 +73,18 @@ To be used where the the button would be an optional call to action - meaning no
 Alternate shade for buttons, currently only intended for use with "Price Boost".
 
 ```jsx react-live
-<div>
-  <Button modifier="alternate" spaced>
-    Default
-  </Button>
-  <Button modifier="alternate" mockState="active" spaced>
-    Hover
-  </Button>
-  <Button modifier="alternate" mockState="focus" spaced>
-    Focus
-  </Button>
-  <Button modifier="alternate" disabled spaced>
-    Disabled
-  </Button>
-</div>
+<Button modifier="alternate" spaced>
+  Default
+</Button>
+<Button modifier="alternate" mockState="active" spaced>
+  Hover
+</Button>
+<Button modifier="alternate" mockState="focus" spaced>
+  Focus
+</Button>
+<Button modifier="alternate" disabled spaced>
+  Disabled
+</Button>
 ```
 
 ## Sizing

--- a/packages/components/src/heading/README.mdx
+++ b/packages/components/src/heading/README.mdx
@@ -14,26 +14,24 @@ We treat semantic and visual/cosmetic decisions as two totally [separate](https:
 Our choice of `h1`–`h6` is a purely semantic decision, and doesn't impact cosmetics configured via the `size` prop.
 
 ```jsx react-live
-<div>
-  <Heading size="alpha" element="h1" color={colors.brand}>
-    Alpha Heading
-  </Heading>
-  <Heading size="bravo" element="h2">
-    Bravo Heading
-  </Heading>
-  <Heading size="charlie" element="h2">
-    Charlie Heading
-  </Heading>
-  <Heading size="delta" element="h2" color={colors.alternate.brand}>
-    Delta Heading
-  </Heading>
-  <Heading size="echo" element="h2">
-    Echo Heading
-  </Heading>
-  <Heading size="foxtrot" element="h2">
-    Foxtrot Heading
-  </Heading>
-</div>
+<Heading size="alpha" element="h1" color={colors.brand}>
+  Alpha Heading
+</Heading>
+<Heading size="bravo" element="h2">
+  Bravo Heading
+</Heading>
+<Heading size="charlie" element="h2">
+  Charlie Heading
+</Heading>
+<Heading size="delta" element="h2" color={colors.alternate.brand}>
+  Delta Heading
+</Heading>
+<Heading size="echo" element="h2">
+  Echo Heading
+</Heading>
+<Heading size="foxtrot" element="h2">
+  Foxtrot Heading
+</Heading>
 ```
 
 ## Props

--- a/packages/components/src/icons/README.mdx
+++ b/packages/components/src/icons/README.mdx
@@ -13,16 +13,14 @@ Icons offer visual aids for common actions and tasks.
 To aid with performance, Icons are surfaced as individual [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) components. Each icon component is prefixed with `Icon`.
 
 ```jsx react-live
-<div>
-  <IconChevronDown />
-  <IconChevronLeft />
-  <IconChevronRight />
-  <IconChevronUp />
-  <IconChevronUpDown />
-  <IconClose />
-  <IconLeftArrowCurveRight />
-  <IconSettings />
-</div>
+<IconChevronDown />
+<IconChevronLeft />
+<IconChevronRight />
+<IconChevronUp />
+<IconChevronUpDown />
+<IconClose />
+<IconLeftArrowCurveRight />
+<IconSettings />
 ```
 
 ## Customizing

--- a/packages/components/src/tooltip/README.mdx
+++ b/packages/components/src/tooltip/README.mdx
@@ -12,7 +12,7 @@ import { PropsTable } from 'docs';
 Tooltips offer further contextual information to users.
 
 ```jsx react-live
-<div style={{ height: '3em' }}>
+<div css={{ height: '3em' }}>
   <Tooltip active message="Hello, I'm a Tooltip." />
 </div>
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description

- Add support for `css` prop in code examples
- Wrap previews in a `<React.Fragment>` to:
  - make examples cleaner
  - save having to keep making wrapper `<div>`s

## Motivation and Context

As part of my Nav changes I need to show code previews with the `css` prop

## How Has This Been Tested?

N/A

## Screenshots

N/A

## Types of changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [x] I have read the [**contributing guidelines**][contributing].
- [x] My code follows the [code style][code-style] of this project.
- [x] My code meets the [A11Y Web Accessibility Checklist](https://a11yproject.com/checklist). If not, please add justification documentation.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[contributing]: https://github.com/coingaming/sportsbet-design/blob/master/CONTRIBUTING.md
[code-style]: https://github.com/coingaming/sportsbet-design/blob/master/CONTRIBUTING.md#code-style
