### PR TITLE
fix: change btcxe color scheme to light

### DIFF
--- a/packages/themes/src/btcxe/btcxe.ts
+++ b/packages/themes/src/btcxe/btcxe.ts
@@ -60,7 +60,7 @@ const btcxe: Theme = {
     ...supportColors,
     ...color,
   },
-  colorScheme: 'dark',
+  colorScheme: 'light',
 };
 
 export default btcxe;


### PR DESCRIPTION
Just fixing the btcxe theme color scheme (it was wrongly set to dark before).