### PR TITLE
chore: exposed form inputs ref attribute

### DIFF
--- a/packages/components/src/checkbox/Checkbox.tsx
+++ b/packages/components/src/checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import styled from 'styled-components';
 import hideVisually from 'polished/lib/mixins/hideVisually';
 import { uniqueId, inlineSvg, rem } from '@heathmont/moon-utils';
@@ -115,23 +115,16 @@ const CheckboxInput = styled.input(({ theme }) => ({
 /**
  * Checkbox Component
  */
-type CheckboxProps = React.InputHTMLAttributes<HTMLInputElement> &
-  React.RefAttributes<HTMLInputElement> & {
-    id?: string;
-    label?: LabelText;
-    ariaLabel?: string;
-    disabled?: boolean;
-  };
+type CheckboxProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  id?: string;
+  label?: LabelText;
+  ariaLabel?: string;
+  disabled?: boolean;
+};
 
-const Checkbox: React.FC<CheckboxProps> = ({
-  disabled = false,
-  ariaLabel,
-  id,
-  label,
-  ...inputProps
-}) => {
+const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props, ref) => {
+  const { disabled = false, ariaLabel, id, label, ...inputProps } = props;
   const autoId = id || `Checkbox-${uniqueId()}`;
-
   return (
     <CheckboxLabel htmlFor={autoId}>
       <CheckboxInput
@@ -139,12 +132,13 @@ const Checkbox: React.FC<CheckboxProps> = ({
         disabled={disabled}
         type="checkbox"
         aria-label={ariaLabel}
+        ref={ref}
         {...inputProps}
       />
       <CheckboxCaption>{label}</CheckboxCaption>
     </CheckboxLabel>
   );
-};
+});
 
 export { CheckboxProps };
 

--- a/packages/components/src/select/Select.tsx
+++ b/packages/components/src/select/Select.tsx
@@ -1,12 +1,11 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { Label, LabelSizing } from '../private/label/label';
 
 import { SelectElement, SelectElementProps } from './private/element';
 
 type SelectProps = LabelSizing &
-  React.InputHTMLAttributes<HTMLSelectElement> &
-  React.RefAttributes<HTMLSelectElement> & {
+  React.InputHTMLAttributes<HTMLSelectElement> & {
     label?: string;
     disabled?: boolean;
   } & SelectElementProps;
@@ -14,21 +13,23 @@ type SelectProps = LabelSizing &
 /**
  * Component
  */
-const Select: React.FC<SelectProps> = ({
-  children,
-  disabled,
-  label,
-  fullWidth,
-  flex,
-  inputGrow,
-  ...props
-}) => {
+const Select = forwardRef<HTMLSelectElement, SelectProps>((props, ref) => {
+  const {
+    children,
+    disabled,
+    label,
+    fullWidth,
+    flex,
+    inputGrow,
+    ...rest
+  } = props;
   const SelectInput = (
     <SelectElement
       withIcon
       fullWidth={fullWidth}
       disabled={disabled}
-      {...props}
+      ref={ref}
+      {...rest}
     >
       {children}
     </SelectElement>
@@ -41,7 +42,7 @@ const Select: React.FC<SelectProps> = ({
   ) : (
     SelectInput
   );
-};
+});
 
 export { SelectProps };
 

--- a/packages/components/src/textInput/TextInput.tsx
+++ b/packages/components/src/textInput/TextInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import styled from 'styled-components';
 
 import { Label } from '../private/label/label';
@@ -22,14 +22,13 @@ type TextInputTypes =
   | 'time'
   | 'url';
 
-type TextInputProps = React.InputHTMLAttributes<HTMLInputElement> &
-  React.RefAttributes<HTMLInputElement> & {
-    label?: string;
-    type?: TextInputTypes;
-    placeholder?: string;
-    error?: boolean | string;
-    rounded?: boolean;
-  };
+type TextInputProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  label?: string;
+  type?: TextInputTypes;
+  placeholder?: string;
+  error?: boolean | string;
+  rounded?: boolean;
+};
 
 const TextInputElem = styled(Input as any)(({ error, theme: { color } }) => ({
   '&:focus': {
@@ -44,25 +43,31 @@ const TextInputElem = styled(Input as any)(({ error, theme: { color } }) => ({
  * 1. Leaving the placeholder as an empty string by default allows us to float
  *    the label when a user starts typing, even if a placeholder isn't defined.
  */
-const TextInput: React.FC<TextInputProps> = ({
-  type = 'text',
-  disabled,
-  placeholder = ' ',
-  label,
-  error,
-  rounded,
-  ...props
-}) => {
+const TextInput = forwardRef<HTMLInputElement, TextInputProps>((props, ref) => {
+  const {
+    type = 'text',
+    disabled,
+    placeholder = ' ',
+    label,
+    error,
+    rounded,
+    ...rest
+  } = props;
   const inputProps = {
     disabled,
     type,
     placeholder,
     rounded,
-    ...props,
+    ...rest,
   };
 
   const TextInputInner = () => (
-    <TextInputElem rounded={!!rounded} error={!!error} {...inputProps} />
+    <TextInputElem
+      rounded={!!rounded}
+      error={!!error}
+      ref={ref}
+      {...inputProps}
+    />
   );
 
   if (!label) {
@@ -77,7 +82,7 @@ const TextInput: React.FC<TextInputProps> = ({
       </>
     </Label>
   );
-};
+});
 
 export { TextInputProps };
 


### PR DESCRIPTION
Added ref attributes to form inputs

## Description

<!---
  Describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## How Has This Been Tested?

<!---
  Please describe in detail how you tested your changes.
  Include details of your testing environment, and the tests you ran to
  see how your change affects other areas of the code, etc.
-->

## Screenshots

<!-- If appropriate -->

## Types of changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [ ] I have read the [**contributing guidelines**][contributing].
- [ ] My code follows the [code style][code-style] of this project.
- [ ] All new and existing tests passed.
- [ ] My HTML markup is valid and meets [W3C standards](https://validator.w3.org/).
- [ ] My styles avoid hard-coded 'magic' values and make use of the design tokens available in themes.
- [ ] My code meets the [A11Y Web Accessibility Checklist](https://a11yproject.com/checklist). If not, please add justification documentation.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/coingaming/moon-design/blob/master/CONTRIBUTING.md
[code-style]: https://github.com/coingaming/moon-design/blob/master/CONTRIBUTING.md#code-style
