### PR TITLE
fix: proper search onChange prop type

### DIFF
--- a/packages/components/src/search/Search.tsx
+++ b/packages/components/src/search/Search.tsx
@@ -11,7 +11,6 @@ interface Result {
 
 export type SearchProps = {
   onSubmit?: (e: React.FormEvent<HTMLFormElement>) => void;
-  onChange?: (e: React.FormEvent<HTMLInputElement>) => void;
   query?: string;
   results?: [Result];
   loadingMessage?: JSX.Element;


### PR DESCRIPTION
Fix Search component onChange type

## Description

Search component `onChange` type was set as `React.FormEvent` that is applicable only for `onSubmit` events. In this type, `event.target.value` does not exists, for example.

This fix changes it to `React.ChangeEvent<HTMLInputElement>`.

## How Has This Been Tested?

<!---
  Please describe in detail how you tested your changes.
  Include details of your testing environment, and the tests you ran to
  see how your change affects other areas of the code, etc.
-->

## Screenshots

<!-- If appropriate -->

## Types of changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [ ] I have read the [**contributing guidelines**][contributing].
- [ ] My code follows the [code style][code-style] of this project.
- [ ] All new and existing tests passed.
- [ ] My HTML markup is valid and meets [W3C standards](https://validator.w3.org/).
- [ ] My styles avoid hard-coded 'magic' values and make use of the design tokens available in themes.
- [ ] My code meets the [A11Y Web Accessibility Checklist](https://a11yproject.com/checklist). If not, please add justification documentation.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/coingaming/moon-design/blob/master/CONTRIBUTING.md
[code-style]: https://github.com/coingaming/moon-design/blob/master/CONTRIBUTING.md#code-style
