### PR TITLE
fix: ensure the Stack grid doesn't overflow the parent's width

### DIFF
--- a/packages/components/src/stackMixin/stackMixin.tsx
+++ b/packages/components/src/stackMixin/stackMixin.tsx
@@ -20,6 +20,8 @@ const stackMixin = (space: StackSpace) => ({
   },
   /* Ensure direct child list-items render without bullets */
   '& > li': listItemStyleTypeNone,
+  /* Ensure the grid doesn't overflow the parent width */
+  gridTemplateColumns: 'minmax(100px,1fr)',
 });
 
 export default stackMixin;


### PR DESCRIPTION
Small change to ensure the Stack's grid doesn't overflow the parent's width

## Description

<!---
  Describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## How Has This Been Tested?

<!---
  Please describe in detail how you tested your changes.
  Include details of your testing environment, and the tests you ran to
  see how your change affects other areas of the code, etc.
-->

## Screenshots

<!-- If appropriate -->

## Types of changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [ ] I have read the [**contributing guidelines**][contributing].
- [ ] My code follows the [code style][code-style] of this project.
- [ ] All new and existing tests passed.
- [ ] My HTML markup is valid and meets [W3C standards](https://validator.w3.org/).
- [ ] My styles avoid hard-coded 'magic' values and make use of the design tokens available in themes.
- [ ] My code meets the [A11Y Web Accessibility Checklist](https://a11yproject.com/checklist). If not, please add justification documentation.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/coingaming/moon-design/blob/master/CONTRIBUTING.md
[code-style]: https://github.com/coingaming/moon-design/blob/master/CONTRIBUTING.md#code-style
