### PR TITLE
fix: B1M2-1729 add boundry option into withHorizantalScroll

### DIFF
--- a/packages/components/src/withHorizontalScroll/withHorizontalScroll.ts
+++ b/packages/components/src/withHorizontalScroll/withHorizontalScroll.ts
@@ -6,6 +6,7 @@ export const THRESHOLD = 0.75;
 
 type Options = {
   scrollStep?: number;
+  scrollInContainer?: boolean;
 };
 
 const findLastVisibleIndex = (childRefs: any[]): any => {
@@ -19,14 +20,21 @@ const findLastVisibleIndex = (childRefs: any[]): any => {
   return finalIndex;
 };
 
-const findFirstVisibleIndex = (childRefs: any[]): any => childRefs.findIndex((child) => child.getAttribute('visible'));
+const findFirstVisibleIndex = (childRefs: any[]): any => {
+  return childRefs.findIndex((child) => child.getAttribute('visible'));
+};
 
-const scrollToIndex = (itemRef: HTMLElement, scrollIntoViewSmoothly: any) => {
+const scrollToIndex = (
+  itemRef: HTMLElement,
+  scrollIntoViewSmoothly: any,
+  containerRef?: any
+) => {
   if (itemRef) {
     scrollIntoViewSmoothly(itemRef, {
       block: 'nearest',
       inline: 'nearest',
       behavior: 'smooth',
+      boundary: containerRef,
     });
   }
 };
@@ -35,23 +43,35 @@ const scrollLeftToStep = (
   scrollStep: number,
   itemRefs: HTMLElement[],
   scrollIntoViewSmoothly: any,
+  containerRef?: any,
 ) => {
   const firstVisibleIndex = findFirstVisibleIndex(itemRefs);
-  const actualScrollForIndex = firstVisibleIndex < scrollStep ? 0 : firstVisibleIndex - scrollStep;
-  scrollToIndex(itemRefs[actualScrollForIndex], scrollIntoViewSmoothly);
+  const actualScrollForIndex =
+    firstVisibleIndex < scrollStep ? 0 : firstVisibleIndex - scrollStep;
+  scrollToIndex(
+    itemRefs[actualScrollForIndex],
+    scrollIntoViewSmoothly,
+    containerRef
+  );
 };
 
 const scrollRightToStep = (
   scrollStep: number,
   itemRefs: HTMLElement[],
   scrollIntoViewSmoothly: any,
+  containerRef?: any,
 ) => {
   const lastVisibleIndex = findLastVisibleIndex(itemRefs);
   const lastIndex = itemRefs.length - 1;
-  const actualScrollForIndex = lastIndex - lastVisibleIndex < scrollStep
-    ? lastIndex
-    : lastVisibleIndex + scrollStep;
-  scrollToIndex(itemRefs[actualScrollForIndex], scrollIntoViewSmoothly);
+  const actualScrollForIndex =
+    lastIndex - lastVisibleIndex < scrollStep
+      ? lastIndex
+      : lastVisibleIndex + scrollStep;
+  scrollToIndex(
+    itemRefs[actualScrollForIndex],
+    scrollIntoViewSmoothly,
+    containerRef
+  );
 };
 
 const showHideIndicator = (
@@ -59,7 +79,7 @@ const showHideIndicator = (
   setLeftIndicator: (isShow: boolean) => void,
   setRightIndicator: (isShow: boolean) => void,
   setFirstVisibleIndex: (index: number) => void,
-  setLastVisibleIndex: (index: number) => void,
+  setLastVisibleIndex: (index: number) => void
 ) => {
   const firstVisibleIndex = findFirstVisibleIndex(itemRefs);
   const lastVisibleIndex = findLastVisibleIndex(itemRefs);
@@ -82,7 +102,7 @@ export const withHorizontalScroll = (options: Options): any => {
   const [lastVisibleIndex, setLastVisibleIndex] = React.useState(-1);
   const containerRef = React.useRef(null);
 
-  const { scrollStep } = options;
+  const { scrollStep, scrollInContainer } = options;
   const itemRefs: HTMLElement[] = [];
   let scrollIntoViewSmoothly: any = scrollIntoView;
 
@@ -98,14 +118,14 @@ export const withHorizontalScroll = (options: Options): any => {
             setLeftIndicator,
             setRightIndicator,
             setFirstVisibleIndex,
-            setLastVisibleIndex,
+            setLastVisibleIndex
           );
         });
       },
       {
         root: containerRef.current,
         threshold: THRESHOLD,
-      },
+      }
     );
 
     itemRefs.forEach((item) => {
@@ -115,9 +135,10 @@ export const withHorizontalScroll = (options: Options): any => {
 
   React.useEffect(() => {
     if (document) {
-      scrollIntoViewSmoothly = 'scrollBehavior' in document.documentElement.style
-        ? scrollIntoView
-        : smoothScrollIntoView;
+      scrollIntoViewSmoothly =
+        'scrollBehavior' in document.documentElement.style
+          ? scrollIntoView
+          : smoothScrollIntoView;
     }
   });
 
@@ -134,11 +155,25 @@ export const withHorizontalScroll = (options: Options): any => {
     firstVisibleIndex,
     lastVisibleIndex,
     scrollLeftToStep: () =>
-      scrollLeftToStep(scrollStep || 0, itemRefs, scrollIntoViewSmoothly),
+      scrollLeftToStep(
+        scrollStep || 0,
+        itemRefs,
+        scrollIntoViewSmoothly,
+        scrollInContainer && containerRef?.current
+      ),
     scrollRightToStep: () =>
-      scrollRightToStep(scrollStep || 0, itemRefs, scrollIntoViewSmoothly),
+      scrollRightToStep(
+        scrollStep || 0,
+        itemRefs,
+        scrollIntoViewSmoothly,
+        scrollInContainer && containerRef?.current
+      ),
     scrollToIndex: (index: number) =>
-      scrollToIndex(itemRefs[index], scrollIntoViewSmoothly),
+      scrollToIndex(
+        itemRefs[index],
+        scrollIntoViewSmoothly,
+        scrollInContainer && containerRef?.current
+      ),
     canScrollLeft: leftIndicator,
     canScrollRight: rightIndicator,
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
We needed to use the boundary option of scroll-into-view-if-needed because without that It scrolls the page as well.

added scrollInContainer into props of withHorizontalScroll. If scrollInContainer is true It will use the container as a boundary.
## Screenshot and description 

<!---
  Describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Types of changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [ x] I have read the [**contributing guidelines**][contributing].
- [ x] My code follows the [code style][code-style] of this project.
- [ ] All new and existing tests passed.
- [ ] My HTML markup is valid and meets [W3C standards](https://validator.w3.org/).
- [ ] My styles avoid hard-coded 'magic' values and make use of the design tokens available in themes.
- [ ] My code meets the [A11Y Web Accessibility Checklist](https://a11yproject.com/checklist). If not, please add justification documentation.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/coingaming/moon-design/blob/master/CONTRIBUTING.md
[code-style]: https://github.com/coingaming/moon-design/blob/master/CONTRIBUTING.md#code-style
