### PR TITLE
fix: carousel freezing when step equal one [B1M2-2794]

### DIFF
--- a/packages/components/src/withHorizontalScroll/withHorizontalScroll.ts
+++ b/packages/components/src/withHorizontalScroll/withHorizontalScroll.ts
@@ -27,12 +27,13 @@ const findFirstVisibleIndex = (childRefs: any[]): any => {
 const scrollToIndex = (
   itemRef: HTMLElement,
   scrollIntoViewSmoothly: any,
-  containerRef?: any
+  containerRef?: any,
+  scrollStep?: number
 ) => {
   if (itemRef) {
     scrollIntoViewSmoothly(itemRef, {
       block: 'nearest',
-      inline: 'nearest',
+      inline: scrollStep === 1 ? 'center' : 'nearest',
       behavior: 'smooth',
       boundary: containerRef,
     });
@@ -43,7 +44,7 @@ const scrollLeftToStep = (
   scrollStep: number,
   itemRefs: HTMLElement[],
   scrollIntoViewSmoothly: any,
-  containerRef?: any,
+  containerRef?: any
 ) => {
   const firstVisibleIndex = findFirstVisibleIndex(itemRefs);
   const actualScrollForIndex =
@@ -51,7 +52,8 @@ const scrollLeftToStep = (
   scrollToIndex(
     itemRefs[actualScrollForIndex],
     scrollIntoViewSmoothly,
-    containerRef
+    containerRef,
+    scrollStep
   );
 };
 
@@ -59,7 +61,7 @@ const scrollRightToStep = (
   scrollStep: number,
   itemRefs: HTMLElement[],
   scrollIntoViewSmoothly: any,
-  containerRef?: any,
+  containerRef?: any
 ) => {
   const lastVisibleIndex = findLastVisibleIndex(itemRefs);
   const lastIndex = itemRefs.length - 1;
@@ -70,7 +72,8 @@ const scrollRightToStep = (
   scrollToIndex(
     itemRefs[actualScrollForIndex],
     scrollIntoViewSmoothly,
-    containerRef
+    containerRef,
+    scrollStep
   );
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Screenshot and description 

<!---
  Describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Types of changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [ ] I have read the [**contributing guidelines**][contributing].
- [ ] My code follows the [code style][code-style] of this project.
- [ ] All new and existing tests passed.
- [ ] My HTML markup is valid and meets [W3C standards](https://validator.w3.org/).
- [ ] My styles avoid hard-coded 'magic' values and make use of the design tokens available in themes.
- [ ] My code meets the [A11Y Web Accessibility Checklist](https://a11yproject.com/checklist). If not, please add justification documentation.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/coingaming/moon-design/blob/master/CONTRIBUTING.md
[code-style]: https://github.com/coingaming/moon-design/blob/master/CONTRIBUTING.md#code-style
