### PR TITLE
fix: use row object in onDropRow event

### DIFF
--- a/next-docs/pages/components/draggabletable.tsx
+++ b/next-docs/pages/components/draggabletable.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { DraggableTable } from '@heathmont/moon-draggabletable';
+import Preview from '../../components/codePreview/Preview';
+
+const PreviewDraggableTable = () => {
+  return (
+    <Preview
+      title="Draggable table"
+      preview={
+        <DraggableTable
+          columns={[
+            {
+              Header: 'Name',
+              accessor: 'name',
+            },
+            {
+              Header: 'Status',
+              accessor: 'status',
+            },
+            {
+              Header: 'User Type',
+              accessor: 'userType',
+            },
+            {
+              Header: 'Language',
+              accessor: 'language',
+            },
+            {
+              Header: 'Product',
+              accessor: 'product',
+            },
+            {
+              Header: 'Views',
+              accessor: 'views',
+            },
+            {
+              Header: 'Region',
+              accessor: 'region',
+            },
+            {
+              Header: 'Tags',
+              accessor: 'tags',
+            },
+          ]}
+          data={[
+            {
+              id: 0,
+              name: 'Amelia',
+              status: 'ACTIVE',
+              userType: 'REGISTERED',
+              language: 'en',
+              product: 'Jackets',
+              views: '22',
+              region: 'EU',
+              tags: 'UK, DE',
+            },
+            {
+              id: 1,
+              name: 'Poppy',
+              status: 'ACTIVE',
+              userType: 'REGISTERED',
+              language: 'en',
+              product: 'Athletic',
+              views: '0',
+              region: 'All',
+              tags: 'LatAm',
+            },
+            {
+              id: 2,
+              name: 'Olivia',
+              status: 'INACTIVE',
+              userType: 'ANONYMOUS',
+              language: 'de',
+              product: 'United',
+              views: '6',
+              region: 'EU',
+              tags: 'FR',
+            },
+            {
+              id: 3,
+              name: 'Ava',
+              status: 'ACTIVE',
+              userType: 'REGISTERED',
+              language: 'en',
+              product: 'Jackets',
+              views: '10',
+              region: 'EU',
+              tags: 'ET, LV',
+            },
+            {
+              id: 4,
+              name: 'Emily',
+              status: 'ACTIVE',
+              userType: 'ANONYMOUS',
+              language: 'de',
+              product: 'S',
+              views: '71',
+              region: 'EU',
+              tags: 'UK, DE',
+            },
+          ]}
+          onDropRow={(row: any, index: number) => {}}
+        />
+      }
+    />
+  );
+};
+
+export default function PageDraggableTable() {
+  return (
+    <>
+      <section className="mt-8">
+        <h1 className="text-5xl font-semibold">DraggableTable</h1>
+      </section>
+      <section className="mt-8">
+        <PreviewDraggableTable />
+      </section>
+    </>
+  );
+}

--- a/packages/draggabletable/src/DraggableTable.tsx
+++ b/packages/draggabletable/src/DraggableTable.tsx
@@ -31,14 +31,14 @@ const DndTD = styled(TD)<{
 }>(({ theme: { color }, variant, dragIndicator }) => ({
   ...(variant === 'calendar'
     ? {
-      '&:first-child, &:nth-child(2)': {
-        borderRadius: 0,
-        backgroundColor: color.goku[100],
-        '&::after': {
-          display: 'none',
+        '&:first-child, &:nth-child(2)': {
+          borderRadius: 0,
+          backgroundColor: color.goku[100],
+          '&::after': {
+            display: 'none',
+          },
         },
-      },
-    }
+      }
     : {}),
   ...(dragIndicator && { cursor: 'grab' }),
 }));
@@ -50,37 +50,37 @@ const DndBodyTR = styled(BodyTR)<{
   ({ theme: { color }, variant, hasOnRowClickHandler }) => ({
     ...(hasOnRowClickHandler
       ? {
-        '&:hover': {
-          zIndex: 1,
-          position: 'relative',
-          cursor: 'pointer',
-          [TD]: {
-            ...(variant === 'calendar'
-              ? {
-                '&:first-child, &:nth-child(2)': {
-                  boxShadow: 'none',
-                },
-              }
-              : {}),
+          '&:hover': {
+            zIndex: 1,
+            position: 'relative',
+            cursor: 'pointer',
+            [TD]: {
+              ...(variant === 'calendar'
+                ? {
+                    '&:first-child, &:nth-child(2)': {
+                      boxShadow: 'none',
+                    },
+                  }
+                : {}),
+            },
           },
-        },
-      }
+        }
       : {}),
     '&:nth-child(even), &:nth-child(odd)': {
       [TD]: {
         ...(variant === 'calendar'
           ? {
-            '&:first-child, &:nth-child(2)': {
-              backgroundColor: color.goku[100],
-              borderRadius: 0,
-            },
-          }
+              '&:first-child, &:nth-child(2)': {
+                backgroundColor: color.goku[100],
+                borderRadius: 0,
+              },
+            }
           : {}),
       },
     },
   }),
   'display: flex;',
-  'flex: 1 0 auto;',
+  'flex: 1 0 auto;'
 );
 
 const DND_ITEM_TYPE = 'rowDnd';
@@ -107,14 +107,15 @@ const Row: React.FC<any> = ({
       const hoverIndex = index;
       if (dragIndex === hoverIndex) return;
       const hoverBoundingRect = dropRef?.current?.getBoundingClientRect();
-      const hoverRowCenter = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
+      const hoverRowCenter =
+        (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
       const clientOffset = monitor.getClientOffset();
       const hoverRowPosition = clientOffset
         ? clientOffset.y - hoverBoundingRect.top
         : 0;
       if (
-        (dragIndex < hoverIndex && hoverRowPosition < hoverRowCenter)
-        || (dragIndex > hoverIndex && hoverRowPosition > hoverRowCenter)
+        (dragIndex < hoverIndex && hoverRowPosition < hoverRowCenter) ||
+        (dragIndex > hoverIndex && hoverRowPosition > hoverRowCenter)
       ) {
         return;
       }
@@ -122,7 +123,7 @@ const Row: React.FC<any> = ({
       dragItem.index = hoverIndex;
     },
     drop(item: any) {
-      dropRow(row.id, item.index);
+      dropRow(row, item.index);
     },
   });
 
@@ -149,12 +150,12 @@ const Row: React.FC<any> = ({
         <IconDrag fontSize="1.2rem" />
       </DndTD>
       {row.cells.map((cell: any) => (
-          <DndTD
-            {...cell.getCellProps()}
-            onClick={hasOnRowClickHandler ? () => onRowClick(row) : undefined}
-          >
-            {cell.render('Cell')}
-          </DndTD>
+        <DndTD
+          {...cell.getCellProps()}
+          onClick={hasOnRowClickHandler ? () => onRowClick(row) : undefined}
+        >
+          {cell.render('Cell')}
+        </DndTD>
       ))}
     </DndBodyTR>
   );
@@ -189,13 +190,13 @@ const DraggableTable: React.FC<any> = ({
             [dragIndex, 1],
             [hoverIndex, 0, dragRecord],
           ],
-        }),
+        })
       );
     },
-    [records],
+    [records]
   );
 
-  const dropRow = (rowId: any, index: any) => onDropRow(rowId, index);
+  const dropRow = (row: any, index: any) => onDropRow(row, index);
 
   const {
     getTableProps,
@@ -213,7 +214,7 @@ const DraggableTable: React.FC<any> = ({
     layout === 'block' ? useBlockLayout : useFlexLayout,
     useResizeColumns,
     useSticky,
-    useExpanded,
+    useExpanded
   );
 
   const lastHeaderGroup = headerGroups[headerGroups.length - 1];
@@ -227,7 +228,7 @@ const DraggableTable: React.FC<any> = ({
 
     setIsScrolledToLeft(target.scrollLeft === 0);
     setIsScrolledToRight(
-      target.scrollLeft + target.clientWidth === target.scrollWidth,
+      target.scrollLeft + target.clientWidth === target.scrollWidth
     );
   };
 
@@ -240,7 +241,10 @@ const DraggableTable: React.FC<any> = ({
         isScrolledToLeft={isScrolledToLeft}
         isScrolledToRight={isScrolledToRight}
         style={{
-          width, height, maxWidth, maxHeight,
+          width,
+          height,
+          maxWidth,
+          maxHeight,
         }}
       >
         <Header>
@@ -284,7 +288,8 @@ const DraggableTable: React.FC<any> = ({
         <Body {...getTableBodyProps()}>
           {rows.map((row, index) => {
             prepareRow(row);
-            const backgroundColor = index % 2 ? evenRowBackgroundColor : defaultRowBackgroundColor
+            const backgroundColor =
+              index % 2 ? evenRowBackgroundColor : defaultRowBackgroundColor;
             return (
               <Row
                 index={index}
@@ -304,9 +309,7 @@ const DraggableTable: React.FC<any> = ({
         {withFooter && (
           <Footer>
             {footerGroups.map((footerGroup) => (
-              <HeaderTR
-                {...footerGroup.getFooterGroupProps()}
-              >
+              <HeaderTR {...footerGroup.getFooterGroupProps()}>
                 {footerGroup.headers.map((column) => (
                   <TH {...column.getFooterProps()}>
                     {column.render('Footer')}


### PR DESCRIPTION
Draggable Table: use row object in onDropRow event

## Screenshot and description 

This change is needed in order to get the origin data bound to the row

## Types of changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [x] I have read the [**contributing guidelines**][contributing].
- [x] My code follows the [code style][code-style] of this project.
- [x] All new and existing tests passed.
- [x] My HTML markup is valid and meets [W3C standards](https://validator.w3.org/).
- [x] My styles avoid hard-coded 'magic' values and make use of the design tokens available in themes.
- [x] My code meets the [A11Y Web Accessibility Checklist](https://a11yproject.com/checklist). If not, please add justification documentation.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/coingaming/moon-design/blob/master/CONTRIBUTING.md
[code-style]: https://github.com/coingaming/moon-design/blob/master/CONTRIBUTING.md#code-style
