### PR TITLE
refactor(sidebar.tsx checkbox.tsx): replace null-coalescing operator …

### DIFF
--- a/next-docs/components/sidebar/Sidebar.tsx
+++ b/next-docs/components/sidebar/Sidebar.tsx
@@ -116,7 +116,7 @@ export default function Sidebar() {
               key={item.name}
               item={{
                 name: item.name,
-                href: item.href ?? '',
+                href: (item.href == null) ? '' : item.href,
                 children: item.children as ItemType[],
               }}
             />

--- a/next-docs/components/sidebar/Sidebar.tsx
+++ b/next-docs/components/sidebar/Sidebar.tsx
@@ -116,7 +116,7 @@ export default function Sidebar() {
               key={item.name}
               item={{
                 name: item.name,
-                href: (item.href == null) ? '' : item.href,
+                href: (!item.href) ? '' : item.href,
                 children: item.children as ItemType[],
               }}
             />

--- a/packages/components/src/checkbox/Checkbox.tsx
+++ b/packages/components/src/checkbox/Checkbox.tsx
@@ -139,7 +139,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props, ref) => {
     ...inputProps
   } = props;
   const autoId = id || `Checkbox-${uniqueId()}`;
-  const checkboxKey = key ?? autoId;
+  const checkboxKey = (key == null ) ? autoId : key;
   return (
     <CheckboxLabel htmlFor={autoId}>
       <CheckboxInput

--- a/packages/components/src/checkbox/Checkbox.tsx
+++ b/packages/components/src/checkbox/Checkbox.tsx
@@ -139,7 +139,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props, ref) => {
     ...inputProps
   } = props;
   const autoId = id || `Checkbox-${uniqueId()}`;
-  const checkboxKey = (key == null ) ? autoId : key;
+  const checkboxKey = (!key) ? autoId : key;
   return (
     <CheckboxLabel htmlFor={autoId}>
       <CheckboxInput


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
sportsbet-apollo uses node 12 which does not support null-coalescing. So it's usage is reverted to tenary operators.
## Screenshot and description

<!---
  Describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [ ] You attached screenshots or added description about changes
- [x] You use [conventional commits naming](https://www.conventionalcommits.org/en/v1.0.0/), e.g. `fix: your changes description [TicketNumber]`, `feat: your feature name [TicketNumber]`
- [ ] You have updated the documentation accordingly.
