### PR TITLE
fix: Dialog to support ColorCodes (e.g gohan.100 etc)

### DIFF
--- a/packages/components/src/dialog/private/layout.ts
+++ b/packages/components/src/dialog/private/layout.ts
@@ -1,20 +1,25 @@
 import rem from 'polished/lib/helpers/rem';
 import styled from 'styled-components';
 import { ColorProps } from '@heathmont/moon-themes';
-import { mq } from '@heathmont/moon-utils';
+import { mq, themed } from '@heathmont/moon-utils';
 
 /* Layout
   =========================================== */
 
 export const DialogContainer = styled.div<{ variant?: 'default' | 'new', backgroundColor?: ColorProps }>(
-  ( { backgroundColor, theme: { color, radius, boxShadow }, variant }) => ({
+  ( { theme: { color, radius, boxShadow }, variant }) => ({
     boxShadow,
     position: 'relative',
     outline: 'none',
     borderRadius: variant === 'new' ? rem(16) : rem(radius.small),
     color: color.bulma[100],
     background: variant === 'new' ? color.gohan[100] : color.goku[100],
-    backgroundColor,
+  }),
+  ({ backgroundColor, theme, variant }) => ({
+    backgroundColor:
+      themed('color', backgroundColor)(theme) || (variant === 'new'
+        ? theme.color.gohan[100]
+        : theme.color.goku[100]),
   })
 );
 

--- a/packages/components/src/dialog/private/toggle.ts
+++ b/packages/components/src/dialog/private/toggle.ts
@@ -1,14 +1,14 @@
 import hideVisually from 'polished/lib/mixins/hideVisually';
 import styled from 'styled-components';
 import { ColorProps } from '@heathmont/moon-themes';
-import { focus, rem } from '@heathmont/moon-utils';
+import { focus, rem, themed } from '@heathmont/moon-utils';
 
 type DialogToggleProps = {
   backgroundColor?: ColorProps;
   heading?: boolean;
 };
 export const DialogToggle = styled.button<DialogToggleProps>(
-  ({ backgroundColor, theme: { border, color, opacity, radius, space }, heading }) => ({
+  ({ theme: { border, color, opacity, radius, space }, heading }) => ({
     position: heading ? 'relative' : 'absolute',
     top: !heading && rem(space.default),
     right: !heading && rem(space.default),
@@ -22,13 +22,15 @@ export const DialogToggle = styled.button<DialogToggleProps>(
     borderRadius: rem(radius.largest),
     border,
     borderColor: 'transparent',
-    backgroundColor: backgroundColor ? backgroundColor : color.gohan[100],
     ...focus(color.piccolo[100]),
     '&:disabled, &[disabled]': {
       cursor: 'not-allowed',
       opacity: opacity.disabled,
     },
-  })
+  }),
+  ({ backgroundColor, theme }) => ({
+    backgroundColor: themed('color', backgroundColor)(theme) || theme.color.gohan[100],
+  }),
 );
 
 export const DialogToggleText = styled.span(hideVisually);


### PR DESCRIPTION
Dialog component needs to accept theme defined color codes as backgroundColor (gohan.100, goku.80 etc)

## Screenshot and description

<!---
  Describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [ ] You attached screenshots or added description about changes
- [ ] You use [conventional commits naming](https://www.conventionalcommits.org/en/v1.0.0/), e.g. `fix: your changes description [TicketNumber]`, `feat: your feature name [TicketNumber]`
- [ ] You have updated the documentation accordingly.
