### PR TITLE
refactor(betaddalight.ts betaddadark.ts): add Whis color override for…

### DIFF
--- a/packages/themes/src/betaddaDark/betaddaDark.ts
+++ b/packages/themes/src/betaddaDark/betaddaDark.ts
@@ -41,6 +41,10 @@ const color = {
   trunks: {
     100: '#97A2AE',
   },
+  whis: {
+    100: '#1DA1F2',
+    10: '#19A9E2',
+  },
 };
 
 const betaddaDark: Theme = {

--- a/packages/themes/src/betaddaLight/betaddaLight.ts
+++ b/packages/themes/src/betaddaLight/betaddaLight.ts
@@ -36,6 +36,10 @@ const lightColors = {
   trunks: {
     100: '#63717B',
   },
+  whis: {
+    100: '#1DA1F2',
+    10: '#19A9E2',
+  },
 };
 
 const betaddaLight: Theme = {


### PR DESCRIPTION
… betadda

<!--- Provide a general summary of your changes in the title above -->

## Screenshot and description
`betadda` Light and Dark theme makes use of the generic `whis` color. The color is slightly lighter that the colors from `sportsbet-site` css package. So I added a new variation of the `whis` color type for sportsbet Light and Dark them

<!---
  Describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [ ] You attached screenshots or added description about changes
- [x ] You use [conventional commits naming](https://www.conventionalcommits.org/en/v1.0.0/), e.g. `fix: your changes description [TicketNumber]`, `feat: your feature name [TicketNumber]`
- [ ] You have updated the documentation accordingly.
