### PR TITLE
fix: make Dialog content scrollable and not crop header [MDS-30]

### DIFF
--- a/packages/components/src/dialogContent/DialogContent.tsx
+++ b/packages/components/src/dialogContent/DialogContent.tsx
@@ -1,6 +1,6 @@
-import styled from 'styled-components';
-import rem from 'polished/lib/helpers/rem';
 import { DialogContent as ReachDialogContent } from '@reach/dialog';
+import rem from 'polished/lib/helpers/rem';
+import styled from 'styled-components';
 
 export interface DialogMaxWidth {
   maxWidth?: string;
@@ -24,6 +24,8 @@ const DialogContent: React.FC<any> = styled(ReachDialogContent)
     background: 'transparent',
     margin: '0 auto',
     position: 'relative',
+    maxHeight: '100vh',
+    overflow: 'auto',
     maxWidth: rem(608) /* [1] */,
     padding: 0,
     outline: 'none',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
added a maxHeight to DialogContent
made content scrollable if content exceeds view height
## Screenshot and description

<!---
  Describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [ ] You attached screenshots or added description about changes
- [x] You use [conventional commits naming](https://www.conventionalcommits.org/en/v1.0.0/), e.g. `fix: your changes description [TicketNumber]`, `feat: your feature name [TicketNumber]`
- [ ] You have updated the documentation accordingly.
