### PR TITLE
fix: remove isMounted from carousel useEffect [CS-1299]

### DIFF
--- a/packages/components/src/carousel/Carousel.tsx
+++ b/packages/components/src/carousel/Carousel.tsx
@@ -172,37 +172,28 @@ const Carousel: React.FC<CarouselProps> = ({
     lastVisibleIndex,
   } = withHorizontalScroll({ scrollStep: step || 5 });
 
-  const [isMounted, setIsMounted] = React.useState(false);
-
   React.useEffect(() => {
-    setIsMounted(true);
     if (!selectedIndex) {
       return;
     }
-    if (isMounted) {
-      scrollToIndex(selectedIndex);
-    }
-    return () => setIsMounted(false);
+    scrollToIndex(selectedIndex);
   }, []);
 
   React.useEffect(() => {
     if (!scrollTo) {
       return;
     }
-    if (isMounted) {
-      // We scroll for another extra item because we defined our THRESHOLD = 0.75;
-      // It means that item will be visible for 75%.
-      // We scroll one more to guarantee 100% visibility.
-      // "items.length - 1" because indices start from 0.
-      if (scrollTo && scrollTo < items.length - 1) {
-        scrollToIndex(scrollTo + 1);
-      }
-      // No point for scroll another extra item because that's the last one
-      if (scrollTo && scrollTo === items.length - 1) {
-        scrollToIndex(scrollTo);
-      }
+    // We scroll for another extra item because we defined our THRESHOLD = 0.75;
+    // It means that item will be visible for 75%.
+    // We scroll one more to guarantee 100% visibility.
+    // "items.length - 1" because indices start from 0.
+    if (scrollTo && scrollTo < items.length - 1) {
+      scrollToIndex(scrollTo + 1);
     }
-    return () => setIsMounted(false);
+    // No point for scroll another extra item because that's the last one
+    if (scrollTo && scrollTo === items.length - 1) {
+      scrollToIndex(scrollTo);
+    }
   }, []);
 
   return (


### PR DESCRIPTION
`scrollToIndex` doesn't work with `isMounted` checking

## Screenshot and description

<!---
  Describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [ ] You attached screenshots or added description about changes
- [ ] You use [conventional commits naming](https://www.conventionalcommits.org/en/v1.0.0/), e.g. `fix: your changes description [TicketNumber]`, `feat: your feature name [TicketNumber]`
- [ ] You have updated the documentation accordingly.
