### PR TITLE
fix: show carousel arrows if all items are hidden [CS-1401]

### DIFF
--- a/packages/components/src/withHorizontalScroll/withHorizontalScroll.ts
+++ b/packages/components/src/withHorizontalScroll/withHorizontalScroll.ts
@@ -109,14 +109,18 @@ const showHideIndicator = (
   const lastVisibleIndex = findLastVisibleIndex(itemRefs);
   setFirstVisibleIndex(firstVisibleIndex);
   setLastVisibleIndex(lastVisibleIndex);
-  if (lastVisibleIndex === -1 && firstVisibleIndex === -1) {
-    setLeftIndicator(false);
-    setRightIndicator(false);
-  }
   lastVisibleIndex < itemRefs.length - 1
     ? setRightIndicator(true)
     : setRightIndicator(false);
   firstVisibleIndex > 0 ? setLeftIndicator(true) : setLeftIndicator(false);
+  if (firstVisibleIndex === -1) {
+    itemRefs.length > 0 ?
+    setLeftIndicator(true) : setLeftIndicator(false)
+  }
+  if (lastVisibleIndex === -1) {
+    itemRefs.length > 0 ?
+    setRightIndicator(true) : setRightIndicator(false)
+  }
 };
 
 export const withHorizontalScroll = (options: Options): any => {


### PR DESCRIPTION
[CS-1401](https://coingaming.atlassian.net/browse/CS-1401) - left arrow appears and disappears when clicked on some arrow

## Screenshot and description

When a carousel view displays only one item (like on the image below) and an arrow is clicked there is a moment when no item is checked as visible. In this case a left arrow is disabled.
To solve this problem arrows will be shown when there is no 'visible' item and carousel have items.
![Screenshot 2022-04-25 at 14 33 01](https://user-images.githubusercontent.com/17812832/165080978-3bfded7b-c8fd-4552-84ff-9e7a2471b7f7.png)


## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [x] You attached screenshots or added description about changes
- [x] You use [conventional commits naming](https://www.conventionalcommits.org/en/v1.0.0/), e.g. `fix: your changes description [TicketNumber]`, `feat: your feature name [TicketNumber]`
- [ ] You have updated the documentation accordingly.
