### PR TITLE
fix: Add the borderWidthInteractive as part of the SharedTokens. This is needed by the theme importer script in elixir [MDS-141]

### DIFF
--- a/packages/themes/src/sharedTokens/sharedTokens.ts
+++ b/packages/themes/src/sharedTokens/sharedTokens.ts
@@ -414,6 +414,7 @@ export interface SharedTheme {
   base: Base;
   border: Border;
   borderWidth: BorderWidth;
+  borderWidthInteractive: BorderWidth;
   borderStyle: BorderStyle;
   boxShadow: BoxShadow; // legacy
   breakpoint: Breakpoint;
@@ -464,6 +465,7 @@ const sharedTokens: SharedTheme = {
   },
   borderStyle,
   borderWidth,
+  borderWidthInteractive,
   border: `${borderWidth}px ${borderStyle}`,
   boxShadow: '0px 0px 1px 0px #00000066, 0px 8px 24px -6px #00000029',
   shadows: {


### PR DESCRIPTION
Elixir imports the theme typescript files. `borderWidthInteractive` (`--border-i-width`) is a value used in the new tailwind preset but it is not yet part of the theme ts files. We need to add this so that the theme-importer.ts file in the elixir site will have this value as well.