### PR TITLE
fix: add prop multiple to Dropdown

### DIFF
--- a/next-docs/pages/core/dropdown.tsx
+++ b/next-docs/pages/core/dropdown.tsx
@@ -132,6 +132,13 @@ const Example = () => {
             default: '-',
             description: 'Whether or not the Listbox is open.',
           },
+          {
+            name: 'multiple',
+            type: 'boolean',
+            required: false,
+            default: '-',
+            description: 'Whether multiple options can be selected or not.',
+          },
         ]}
       />
 

--- a/workspaces/core/src/dropdown/Dropdown.tsx
+++ b/workspaces/core/src/dropdown/Dropdown.tsx
@@ -62,6 +62,7 @@ type DropdownRootProps = {
   isError?: boolean;
   disabled?: boolean;
   size?: 'sm' | 'md' | 'lg' | 'xl' | string;
+  multiple?: boolean;
 };
 
 type WithChildren<T = {}> = T & { children?: ReactNode };
@@ -73,6 +74,7 @@ const DropdownRoot: React.FC<WithChildren<DropdownRootProps>> = ({
   isError,
   disabled,
   size = 'md',
+  multiple,
   ...rest
 }) => {
   const referenceElement = useRef(null);
@@ -115,6 +117,7 @@ const DropdownRoot: React.FC<WithChildren<DropdownRootProps>> = ({
           value={value}
           onChange={onChange}
           disabled={disabled}
+          multiple={multiple}
           {...rest}
         >
           {({ open }) => (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Screenshot and description

Added `multiple` to props because typescript doesn't allow to use any props which are not in props type of the component

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [x] You attached screenshots or added description about changes
- [x] You use [conventional commits naming](https://www.conventionalcommits.org/en/v1.0.0/), e.g. `fix: your changes description [TicketNumber]`, `feat: your feature name [TicketNumber]`
- [x] You have updated the documentation accordingly.
