### PR TITLE
feat: remove piccolo colour from bombay theme

### DIFF
--- a/workspaces/themes/src/bombayClub.css
+++ b/workspaces/themes/src/bombayClub.css
@@ -1,5 +1,6 @@
 :root.theme-bombay-club,
 .theme-bombay-club {
+  /* there is no piccolo colour for bombay because it uses brand piccolo colour */
   --hit: 32 32 32; /* #202020 */
   --beerus: 255 255 255 / 0.08; /* #ffffff */
   --gohan: 12 12 12; /* #0c0c0c */

--- a/workspaces/themes/src/bombayClub.css
+++ b/workspaces/themes/src/bombayClub.css
@@ -1,6 +1,5 @@
 :root.theme-bombay-club,
 .theme-bombay-club {
-  --piccolo: 255 79 15; /* #ff4f0f */
   --hit: 32 32 32; /* #202020 */
   --beerus: 255 255 255 / 0.08; /* #ffffff */
   --gohan: 12 12 12; /* #0c0c0c */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Screenshot and description

Bombay club page doesn't have its own piccolo colour, it should use colour of the theme of the site (bitcasino, sportsbet etc)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [ ] You attached screenshots or added description about changes
- [ ] You use [conventional commits naming](https://www.conventionalcommits.org/en/v1.0.0/), e.g. `fix: your changes description [TicketNumber]`, `feat: your feature name [TicketNumber]`
- [ ] You have updated the documentation accordingly.
