### PR TITLE
Fixed: a MenuItem.Title text clipping and MenuItem's Radio and CheckBoxes haven't fixed minWidth

### DIFF
--- a/next-docs/public/examples/combobox/InsetMultiSelect.tsx
+++ b/next-docs/public/examples/combobox/InsetMultiSelect.tsx
@@ -32,7 +32,7 @@ const Example = () => {
   const filteredPeople = filter(query, people);
 
   return (
-    <div className="flex w-full max-w-xs items-center">
+    <div className="flex w-full max-w-xs justify-center items-center">
       <Combobox
         value={selected}
         onChange={setSelected}

--- a/next-docs/public/examples/combobox/InsetSelectStates.tsx
+++ b/next-docs/public/examples/combobox/InsetSelectStates.tsx
@@ -187,7 +187,7 @@ const Example = () => {
             </Combobox.InsetSelect>
             <Combobox.Transition>
               <Combobox.Options
-                menuWidth="w-40"
+                menuWidth="w-36"
                 className="z-5 rounded-moon-s-md box-border bg-gohan shadow-moon-lg py-2 px-1 my-2"
               >
                 {filteredPeople3.length === 0 && query3 !== '' ? (
@@ -199,7 +199,7 @@ const Example = () => {
                     <Combobox.Option value={person} key={index}>
                       {({ selected, active }) => (
                         <MenuItem isActive={active} isSelected={selected}>
-                          <MenuItem.Title>{person.label}</MenuItem.Title>
+                          <MenuItem.Title textClip={true}>{person.label}</MenuItem.Title>
                           <MenuItem.Radio isSelected={selected} />
                         </MenuItem>
                       )}

--- a/next-docs/public/examples/combobox/__tests__/__snapshots__/index.test.tsx.snap
+++ b/next-docs/public/examples/combobox/__tests__/__snapshots__/index.test.tsx.snap
@@ -292,7 +292,7 @@ Object {
         dir="rtl"
       >
         <div
-          class="flex w-full max-w-xs items-center"
+          class="flex w-full max-w-xs justify-center items-center"
         >
           <div
             class="w-full relative"
@@ -363,7 +363,7 @@ Object {
       dir="rtl"
     >
       <div
-        class="flex w-full max-w-xs items-center"
+        class="flex w-full max-w-xs justify-center items-center"
       >
         <div
           class="w-full relative"
@@ -2910,7 +2910,7 @@ Object {
   "baseElement": <body>
     <div>
       <div
-        class="flex w-full max-w-xs items-center"
+        class="flex w-full max-w-xs justify-center items-center"
       >
         <div
           class="w-full relative"
@@ -2977,7 +2977,7 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="flex w-full max-w-xs items-center"
+      class="flex w-full max-w-xs justify-center items-center"
     >
       <div
         class="w-full relative"

--- a/next-docs/public/examples/dropdown/__tests__/__snapshots__/index.test.tsx.snap
+++ b/next-docs/public/examples/dropdown/__tests__/__snapshots__/index.test.tsx.snap
@@ -411,7 +411,7 @@ Object {
                       Wade Cooper
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                     >
                       <span
                         aria-checked="false"
@@ -439,7 +439,7 @@ Object {
                       Arlene Mccoy
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                     >
                       <span
                         aria-checked="false"
@@ -467,7 +467,7 @@ Object {
                       Devon Webb
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                     >
                       <span
                         aria-checked="false"
@@ -495,7 +495,7 @@ Object {
                       Tom Cook
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                     >
                       <span
                         aria-checked="false"
@@ -523,7 +523,7 @@ Object {
                       Tanya Fox
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                     >
                       <span
                         aria-checked="false"
@@ -551,7 +551,7 @@ Object {
                       Hellen Schmidt
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                     >
                       <span
                         aria-checked="false"
@@ -669,7 +669,7 @@ Object {
                     Wade Cooper
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -697,7 +697,7 @@ Object {
                     Arlene Mccoy
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -725,7 +725,7 @@ Object {
                     Devon Webb
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -753,7 +753,7 @@ Object {
                     Tom Cook
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -781,7 +781,7 @@ Object {
                     Tanya Fox
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -809,7 +809,7 @@ Object {
                     Hellen Schmidt
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -984,7 +984,7 @@ Object {
                       Wade Cooper
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center relative"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                     >
                       <span
                         aria-checked="false"
@@ -1028,7 +1028,7 @@ Object {
                       Arlene Mccoy
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center relative"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                     >
                       <span
                         aria-checked="false"
@@ -1072,7 +1072,7 @@ Object {
                       Devon Webb
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center relative"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                     >
                       <span
                         aria-checked="false"
@@ -1116,7 +1116,7 @@ Object {
                       Tom Cook
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center relative"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                     >
                       <span
                         aria-checked="false"
@@ -1160,7 +1160,7 @@ Object {
                       Tanya Fox
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center relative"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                     >
                       <span
                         aria-checked="false"
@@ -1204,7 +1204,7 @@ Object {
                       Hellen Schmidt
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center relative"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                     >
                       <span
                         aria-checked="false"
@@ -1338,7 +1338,7 @@ Object {
                     Wade Cooper
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -1382,7 +1382,7 @@ Object {
                     Arlene Mccoy
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -1426,7 +1426,7 @@ Object {
                     Devon Webb
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -1470,7 +1470,7 @@ Object {
                     Tom Cook
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -1514,7 +1514,7 @@ Object {
                     Tanya Fox
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -1558,7 +1558,7 @@ Object {
                     Hellen Schmidt
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -1748,7 +1748,7 @@ Object {
                       Wade Cooper
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                     >
                       <span
                         aria-checked="false"
@@ -1776,7 +1776,7 @@ Object {
                       Arlene Mccoy
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                     >
                       <span
                         aria-checked="false"
@@ -1804,7 +1804,7 @@ Object {
                       Devon Webb
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                     >
                       <span
                         aria-checked="false"
@@ -1832,7 +1832,7 @@ Object {
                       Tom Cook
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                     >
                       <span
                         aria-checked="false"
@@ -1860,7 +1860,7 @@ Object {
                       Tanya Fox
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                     >
                       <span
                         aria-checked="false"
@@ -1888,7 +1888,7 @@ Object {
                       Hellen Schmidt
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                     >
                       <span
                         aria-checked="false"
@@ -2005,7 +2005,7 @@ Object {
                     Wade Cooper
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -2033,7 +2033,7 @@ Object {
                     Arlene Mccoy
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -2061,7 +2061,7 @@ Object {
                     Devon Webb
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -2089,7 +2089,7 @@ Object {
                     Tom Cook
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -2117,7 +2117,7 @@ Object {
                     Tanya Fox
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -2145,7 +2145,7 @@ Object {
                     Hellen Schmidt
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -3083,7 +3083,7 @@ Object {
                       Wade Cooper
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center relative"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                     >
                       <span
                         aria-checked="false"
@@ -3127,7 +3127,7 @@ Object {
                       Arlene Mccoy
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center relative"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                     >
                       <span
                         aria-checked="false"
@@ -3171,7 +3171,7 @@ Object {
                       Devon Webb
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center relative"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                     >
                       <span
                         aria-checked="false"
@@ -3215,7 +3215,7 @@ Object {
                       Tom Cook
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center relative"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                     >
                       <span
                         aria-checked="false"
@@ -3259,7 +3259,7 @@ Object {
                       Tanya Fox
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center relative"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                     >
                       <span
                         aria-checked="false"
@@ -3303,7 +3303,7 @@ Object {
                       Hellen Schmidt
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center relative"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                     >
                       <span
                         aria-checked="false"
@@ -3562,7 +3562,7 @@ Object {
                     Wade Cooper
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -3606,7 +3606,7 @@ Object {
                     Arlene Mccoy
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -3650,7 +3650,7 @@ Object {
                     Devon Webb
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -3694,7 +3694,7 @@ Object {
                     Tom Cook
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -3738,7 +3738,7 @@ Object {
                     Tanya Fox
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -3782,7 +3782,7 @@ Object {
                     Hellen Schmidt
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -4586,7 +4586,7 @@ Object {
                       Wade Cooper
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                     >
                       <span
                         aria-checked="false"
@@ -4614,7 +4614,7 @@ Object {
                       Arlene Mccoy
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                     >
                       <span
                         aria-checked="false"
@@ -4642,7 +4642,7 @@ Object {
                       Devon Webb
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                     >
                       <span
                         aria-checked="false"
@@ -4670,7 +4670,7 @@ Object {
                       Tom Cook
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                     >
                       <span
                         aria-checked="false"
@@ -4698,7 +4698,7 @@ Object {
                       Tanya Fox
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                     >
                       <span
                         aria-checked="false"
@@ -4726,7 +4726,7 @@ Object {
                       Hellen Schmidt
                     </span>
                     <span
-                      class="flex w-6 h-6 justify-center items-center"
+                      class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                     >
                       <span
                         aria-checked="false"
@@ -4955,7 +4955,7 @@ Object {
                     Wade Cooper
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -4983,7 +4983,7 @@ Object {
                     Arlene Mccoy
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -5011,7 +5011,7 @@ Object {
                     Devon Webb
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -5039,7 +5039,7 @@ Object {
                     Tom Cook
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -5067,7 +5067,7 @@ Object {
                     Tanya Fox
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -5095,7 +5095,7 @@ Object {
                     Hellen Schmidt
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -6874,7 +6874,7 @@ Object {
                     Wade Cooper
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -6902,7 +6902,7 @@ Object {
                     Arlene Mccoy
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -6930,7 +6930,7 @@ Object {
                     Devon Webb
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -6958,7 +6958,7 @@ Object {
                     Tom Cook
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -6986,7 +6986,7 @@ Object {
                     Tanya Fox
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -7014,7 +7014,7 @@ Object {
                     Hellen Schmidt
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -7128,7 +7128,7 @@ Object {
                   Wade Cooper
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                 >
                   <span
                     aria-checked="false"
@@ -7156,7 +7156,7 @@ Object {
                   Arlene Mccoy
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                 >
                   <span
                     aria-checked="false"
@@ -7184,7 +7184,7 @@ Object {
                   Devon Webb
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                 >
                   <span
                     aria-checked="false"
@@ -7212,7 +7212,7 @@ Object {
                   Tom Cook
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                 >
                   <span
                     aria-checked="false"
@@ -7240,7 +7240,7 @@ Object {
                   Tanya Fox
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                 >
                   <span
                     aria-checked="false"
@@ -7268,7 +7268,7 @@ Object {
                   Hellen Schmidt
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                 >
                   <span
                     aria-checked="false"
@@ -7439,7 +7439,7 @@ Object {
                     Wade Cooper
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -7483,7 +7483,7 @@ Object {
                     Arlene Mccoy
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -7527,7 +7527,7 @@ Object {
                     Devon Webb
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -7571,7 +7571,7 @@ Object {
                     Tom Cook
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -7615,7 +7615,7 @@ Object {
                     Tanya Fox
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -7659,7 +7659,7 @@ Object {
                     Hellen Schmidt
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -7789,7 +7789,7 @@ Object {
                   Wade Cooper
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center relative"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                 >
                   <span
                     aria-checked="false"
@@ -7833,7 +7833,7 @@ Object {
                   Arlene Mccoy
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center relative"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                 >
                   <span
                     aria-checked="false"
@@ -7877,7 +7877,7 @@ Object {
                   Devon Webb
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center relative"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                 >
                   <span
                     aria-checked="false"
@@ -7921,7 +7921,7 @@ Object {
                   Tom Cook
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center relative"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                 >
                   <span
                     aria-checked="false"
@@ -7965,7 +7965,7 @@ Object {
                   Tanya Fox
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center relative"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                 >
                   <span
                     aria-checked="false"
@@ -8009,7 +8009,7 @@ Object {
                   Hellen Schmidt
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center relative"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                 >
                   <span
                     aria-checked="false"
@@ -8195,7 +8195,7 @@ Object {
                     Wade Cooper
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -8223,7 +8223,7 @@ Object {
                     Arlene Mccoy
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -8251,7 +8251,7 @@ Object {
                     Devon Webb
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -8279,7 +8279,7 @@ Object {
                     Tom Cook
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -8307,7 +8307,7 @@ Object {
                     Tanya Fox
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -8335,7 +8335,7 @@ Object {
                     Hellen Schmidt
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -8448,7 +8448,7 @@ Object {
                   Wade Cooper
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                 >
                   <span
                     aria-checked="false"
@@ -8476,7 +8476,7 @@ Object {
                   Arlene Mccoy
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                 >
                   <span
                     aria-checked="false"
@@ -8504,7 +8504,7 @@ Object {
                   Devon Webb
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                 >
                   <span
                     aria-checked="false"
@@ -8532,7 +8532,7 @@ Object {
                   Tom Cook
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                 >
                   <span
                     aria-checked="false"
@@ -8560,7 +8560,7 @@ Object {
                   Tanya Fox
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                 >
                   <span
                     aria-checked="false"
@@ -8588,7 +8588,7 @@ Object {
                   Hellen Schmidt
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                 >
                   <span
                     aria-checked="false"
@@ -9514,7 +9514,7 @@ Object {
                     Wade Cooper
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -9558,7 +9558,7 @@ Object {
                     Arlene Mccoy
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -9602,7 +9602,7 @@ Object {
                     Devon Webb
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -9646,7 +9646,7 @@ Object {
                     Tom Cook
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -9690,7 +9690,7 @@ Object {
                     Tanya Fox
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -9734,7 +9734,7 @@ Object {
                     Hellen Schmidt
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center relative"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                   >
                     <span
                       aria-checked="false"
@@ -9989,7 +9989,7 @@ Object {
                   Wade Cooper
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center relative"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                 >
                   <span
                     aria-checked="false"
@@ -10033,7 +10033,7 @@ Object {
                   Arlene Mccoy
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center relative"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                 >
                   <span
                     aria-checked="false"
@@ -10077,7 +10077,7 @@ Object {
                   Devon Webb
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center relative"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                 >
                   <span
                     aria-checked="false"
@@ -10121,7 +10121,7 @@ Object {
                   Tom Cook
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center relative"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                 >
                   <span
                     aria-checked="false"
@@ -10165,7 +10165,7 @@ Object {
                   Tanya Fox
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center relative"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                 >
                   <span
                     aria-checked="false"
@@ -10209,7 +10209,7 @@ Object {
                   Hellen Schmidt
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center relative"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
                 >
                   <span
                     aria-checked="false"
@@ -11001,7 +11001,7 @@ Object {
                     Wade Cooper
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -11029,7 +11029,7 @@ Object {
                     Arlene Mccoy
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -11057,7 +11057,7 @@ Object {
                     Devon Webb
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -11085,7 +11085,7 @@ Object {
                     Tom Cook
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -11113,7 +11113,7 @@ Object {
                     Tanya Fox
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -11141,7 +11141,7 @@ Object {
                     Hellen Schmidt
                   </span>
                   <span
-                    class="flex w-6 h-6 justify-center items-center"
+                    class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                   >
                     <span
                       aria-checked="false"
@@ -11366,7 +11366,7 @@ Object {
                   Wade Cooper
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                 >
                   <span
                     aria-checked="false"
@@ -11394,7 +11394,7 @@ Object {
                   Arlene Mccoy
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                 >
                   <span
                     aria-checked="false"
@@ -11422,7 +11422,7 @@ Object {
                   Devon Webb
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                 >
                   <span
                     aria-checked="false"
@@ -11450,7 +11450,7 @@ Object {
                   Tom Cook
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                 >
                   <span
                     aria-checked="false"
@@ -11478,7 +11478,7 @@ Object {
                   Tanya Fox
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                 >
                   <span
                     aria-checked="false"
@@ -11506,7 +11506,7 @@ Object {
                   Hellen Schmidt
                 </span>
                 <span
-                  class="flex w-6 h-6 justify-center items-center"
+                  class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
                 >
                   <span
                     aria-checked="false"

--- a/next-docs/public/examples/menuItem/__tests__/__snapshots__/index.test.tsx.snap
+++ b/next-docs/public/examples/menuItem/__tests__/__snapshots__/index.test.tsx.snap
@@ -96,7 +96,7 @@ Object {
           type="button"
         >
           <span
-            class="flex w-6 h-6 justify-center items-center relative"
+            class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
           >
             <span
               aria-checked="false"
@@ -137,7 +137,7 @@ Object {
             Your value
           </span>
           <span
-            class="flex w-6 h-6 justify-center items-center relative"
+            class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
           >
             <span
               aria-checked="false"
@@ -175,7 +175,7 @@ Object {
         type="button"
       >
         <span
-          class="flex w-6 h-6 justify-center items-center relative"
+          class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
         >
           <span
             aria-checked="false"
@@ -216,7 +216,7 @@ Object {
           Your value
         </span>
         <span
-          class="flex w-6 h-6 justify-center items-center relative"
+          class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
         >
           <span
             aria-checked="false"
@@ -1811,7 +1811,7 @@ Object {
             class="px-2"
           >
             <span
-              class="flex w-6 h-6 justify-center items-center relative"
+              class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
             >
               <span
                 aria-checked="false"
@@ -1937,7 +1937,7 @@ Object {
           class="px-2"
         >
           <span
-            class="flex w-6 h-6 justify-center items-center relative"
+            class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
           >
             <span
               aria-checked="false"
@@ -2033,7 +2033,7 @@ Object {
           type="button"
         >
           <span
-            class="flex w-6 h-6 justify-center items-center"
+            class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
           >
             <span
               aria-checked="false"
@@ -2058,7 +2058,7 @@ Object {
             Your value
           </span>
           <span
-            class="flex w-6 h-6 justify-center items-center"
+            class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
           >
             <span
               aria-checked="false"
@@ -2080,7 +2080,7 @@ Object {
         type="button"
       >
         <span
-          class="flex w-6 h-6 justify-center items-center"
+          class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
         >
           <span
             aria-checked="false"
@@ -2105,7 +2105,7 @@ Object {
           Your value
         </span>
         <span
-          class="flex w-6 h-6 justify-center items-center"
+          class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
         >
           <span
             aria-checked="false"
@@ -2582,7 +2582,7 @@ Object {
         type="button"
       >
         <span
-          class="flex w-6 h-6 justify-center items-center relative"
+          class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
         >
           <span
             aria-checked="false"
@@ -2623,7 +2623,7 @@ Object {
           Your value
         </span>
         <span
-          class="flex w-6 h-6 justify-center items-center relative"
+          class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
         >
           <span
             aria-checked="false"
@@ -2657,7 +2657,7 @@ Object {
       type="button"
     >
       <span
-        class="flex w-6 h-6 justify-center items-center relative"
+        class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
       >
         <span
           aria-checked="false"
@@ -2698,7 +2698,7 @@ Object {
         Your value
       </span>
       <span
-        class="flex w-6 h-6 justify-center items-center relative"
+        class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
       >
         <span
           aria-checked="false"
@@ -4265,7 +4265,7 @@ Object {
           class="px-2"
         >
           <span
-            class="flex w-6 h-6 justify-center items-center relative"
+            class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
           >
             <span
               aria-checked="false"
@@ -4387,7 +4387,7 @@ Object {
         class="px-2"
       >
         <span
-          class="flex w-6 h-6 justify-center items-center relative"
+          class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative"
         >
           <span
             aria-checked="false"
@@ -4479,7 +4479,7 @@ Object {
         type="button"
       >
         <span
-          class="flex w-6 h-6 justify-center items-center"
+          class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
         >
           <span
             aria-checked="false"
@@ -4504,7 +4504,7 @@ Object {
           Your value
         </span>
         <span
-          class="flex w-6 h-6 justify-center items-center"
+          class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
         >
           <span
             aria-checked="false"
@@ -4522,7 +4522,7 @@ Object {
       type="button"
     >
       <span
-        class="flex w-6 h-6 justify-center items-center"
+        class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
       >
         <span
           aria-checked="false"
@@ -4547,7 +4547,7 @@ Object {
         Your value
       </span>
       <span
-        class="flex w-6 h-6 justify-center items-center"
+        class="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center"
       >
         <span
           aria-checked="false"

--- a/workspaces/core/src/menuItem/MenuItem.tsx
+++ b/workspaces/core/src/menuItem/MenuItem.tsx
@@ -8,6 +8,9 @@ import mergeClassnames from '../mergeClassnames/mergeClassnames';
 import GenericCheckAlternative from '../private/icons/GenericCheckAlternative';
 import useRegisterChild from '../private/utils/useRegisterChild';
 
+// TODO: Move this type determination into MenuItemsProps file
+type PolymorphicRef<C extends React.ElementType> = React.ComponentPropsWithRef<C>['button']
+
 const MenuItemRoot = React.forwardRef(
   <C extends React.ElementType = 'button'>(
     {
@@ -53,13 +56,16 @@ const MenuItemRoot = React.forwardRef(
   }
 );
 
-const Title = ({ children }: { children?: ReactNode }) => {
+const Title = ({ children, textClip = false }: { children?: ReactNode, textClip?: boolean }) => {
   const { registerChild } = useMenuItemContext('MenuItem.Title');
   useEffect(() => {
     registerChild && registerChild('Title');
   }, []);
   return (
-    <span className="block grow text-start text-bulma overflow-hidden">
+    <span className={mergeClassnames(
+      "block grow text-start text-bulma overflow-hidden",
+      textClip && "break-all truncate"
+    )}>
       {children}
     </span>
   );
@@ -92,7 +98,7 @@ const Radio = ({
   }, []);
   const ariaLabelValue = ariaLabel ? ariaLabel : 'Radio option';
   return (
-    <span className="flex w-6 h-6 justify-center items-center">
+    <span className="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center">
       <span
         role="radio"
         aria-checked={selected}
@@ -122,7 +128,7 @@ const Checkbox = ({
   }, []);
   const ariaLabelValue = ariaLabel ? ariaLabel : 'Checkbox';
   return (
-    <span className="flex w-6 h-6 justify-center items-center relative">
+    <span className="flex w-6 min-w-[24px] h-6 min-h-[24px] justify-center items-center relative">
       <span
         role="checkbox"
         aria-checked={selected}


### PR DESCRIPTION
Text clipping added to MenuItem.Title.
MenuItem.Radio and MenuItem.CheckBox received a restriction on the minimum width and height.

After that all rows with controls in the Combobox samples are srictly aligned.

The Multiselect Combobox is being stretched to its outer container, so this container's width should be set wide enough to provide inner width deviations of the Combobox during selection/reset its items.