### PR TITLE
fix: Default imageUrl for Avatar should be undefined so requests won't be made to './undefined'

### DIFF
--- a/packages/core/src/avatar/Avatar.tsx
+++ b/packages/core/src/avatar/Avatar.tsx
@@ -9,7 +9,7 @@ import type AvatarProps from './private/types/AvatarProps';
 
 const Avatar: React.FC<AvatarProps> = ({
   name,
-  imageUrl = '',
+  imageUrl = undefined,
   color = 'bulma.100',
   backgroundColor = 'gohan.100',
   size = Size.MEDIUM,


### PR DESCRIPTION
When `Avatar` is used without the `imageUrl` property the background image is set to `url(undefined)` or `url('')` while the expected behaviour that there won't be any background image.

## Screenshot and description

<!---
  Describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [ ] You attached screenshots or added description about changes
- [ ] You use [conventional commits naming](https://www.conventionalcommits.org/en/v1.0.0/), e.g. `fix: your changes description [TicketNumber]`, `feat: your feature name [TicketNumber]`
- [ ] You have updated the documentation accordingly.
