### PR TITLE
fix: Fix avatar to set backgroundImage to none instead of `url(undefined)` when imageUrl is not set

### DIFF
--- a/packages/components/src/avatar/Avatar.tsx
+++ b/packages/components/src/avatar/Avatar.tsx
@@ -35,7 +35,7 @@ const AvatarWrapper = styled.div<AvatarProps>(
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
-      backgroundImage: `url(${imageUrl})`,
+      backgroundImage: imageUrl ? `url(${imageUrl})`: 'none',
       backgroundSize: 'cover',
     },
     size === 'xsmall' && {

--- a/packages/core/src/avatar/Avatar.tsx
+++ b/packages/core/src/avatar/Avatar.tsx
@@ -9,7 +9,7 @@ import type AvatarProps from './private/types/AvatarProps';
 
 const Avatar: React.FC<AvatarProps> = ({
   name,
-  imageUrl = '',
+  imageUrl,
   color = 'bulma.100',
   backgroundColor = 'gohan.100',
   size = Size.MEDIUM,
@@ -27,7 +27,6 @@ const Avatar: React.FC<AvatarProps> = ({
     ) : (
       <Wrapper
         size={size}
-        imageUrl={imageUrl}
         color={color}
         backgroundColor={backgroundColor}
       >

--- a/packages/core/src/avatar/styles/Wrapper.ts
+++ b/packages/core/src/avatar/styles/Wrapper.ts
@@ -14,7 +14,7 @@ const Wrapper = styled.div<AvatarProps>(
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
-      backgroundImage: `url(${imageUrl})`,
+      ...(imageUrl ? {backgroundImage: `url(${imageUrl})`}: {}),
       backgroundSize: 'cover',
     },
     setWrapperSize(size),

--- a/packages/core/src/avatar/styles/Wrapper.ts
+++ b/packages/core/src/avatar/styles/Wrapper.ts
@@ -1,7 +1,7 @@
 import { themed } from '@heathmont/moon-utils';
 import styled from 'styled-components';
-import setWrapperSize from '../private/utils/setWrapperSize';
 import type AvatarProps from '../private/types/AvatarProps';
+import setWrapperSize from '../private/utils/setWrapperSize';
 
 const Wrapper = styled.div<AvatarProps>(
   ({ size, imageUrl, color, backgroundColor, theme }) => [
@@ -14,7 +14,7 @@ const Wrapper = styled.div<AvatarProps>(
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
-      ...(imageUrl ? {backgroundImage: `url(${imageUrl})`}: {}),
+      backgroundImage: imageUrl ? `url(${imageUrl})` : 'none',
       backgroundSize: 'cover',
     },
     setWrapperSize(size),

--- a/workspaces/core/src/avatar/styles/Wrapper.tsx
+++ b/workspaces/core/src/avatar/styles/Wrapper.tsx
@@ -23,7 +23,7 @@ const Wrapper = ({
       getBorderRadius(size, isRounded),
       className
     )}
-    style={{ backgroundImage: `url('${imageUrl}')` }}
+    style={{ backgroundImage: imageUrl ? `url('${imageUrl}')` : 'none' }}
   >
     {children}
   </div>


### PR DESCRIPTION
The `url(undefined)` is resulting to http requests to `{domain}/undefined` so the console and the network tab is full or errors.

## Screenshot and description

<!---
  Describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [x] You attached screenshots or added description about changes
- [x] You use [conventional commits naming](https://www.conventionalcommits.org/en/v1.0.0/), e.g. `fix: your changes description [TicketNumber]`, `feat: your feature name [TicketNumber]`
- [x] You have updated the documentation accordingly.
