### PR TITLE
feat: TagsInput remove last element on Backspace

### DIFF
--- a/next-docs/pages/components/tagsInput.tsx
+++ b/next-docs/pages/components/tagsInput.tsx
@@ -25,10 +25,13 @@ const PageTagsInput = () => {
       >
         <p>{text}</p>
         <p>
-          These selected text entries are being dispalyed as tags. Tags represent a set of interactive keywords that help organise and categorise objects.
+          These selected text entries are being displayed as tags. Tags
+          represent a set of interactive keywords that help organize and
+          categorize objects.
         </p>
         <p>
-          Tags can be added by pressing the Enter key or removed by the mouse click from the input element.
+          Tags can be added by pressing the Enter key or removed by Backspace
+          key or the mouse click from the input element.
         </p>
       </ComponentPageDescription>
 
@@ -120,15 +123,15 @@ const PageTagsInput = () => {
             type: '(value: string) => void;',
             required: false,
             default: '-',
-            description: 'The function to select the text and append it to the tag set.',
+            description:
+              'The function to select the text and append it to the tag set.',
           },
           {
             name: 'onClear',
             type: '(index: number) => void',
             required: false,
             default: '-',
-            description:
-              'The function to remove the selected tag.',
+            description: 'The function to remove the selected tag.',
           },
         ]}
       />

--- a/workspaces/core/src/tagsInput/TagsInput.tsx
+++ b/workspaces/core/src/tagsInput/TagsInput.tsx
@@ -85,6 +85,10 @@ const TagsInputRoot = forwardRef<HTMLSpanElement, TagsInputRootProps>(
                   onEnter((e.target as HTMLInputElement).value);
                 e.code === 'Enter' &&
                   ((e.target as HTMLInputElement).value = '');
+                e.code === 'Backspace' &&
+                  selected.length !== 0 &&
+                  onClear &&
+                  onClear(selected.length - 1);
               }}
               onFocus={() => setIsFocused(true)}
               onBlur={() => setIsFocused(false)}

--- a/workspaces/core/src/tagsInput/TagsInput.tsx
+++ b/workspaces/core/src/tagsInput/TagsInput.tsx
@@ -86,6 +86,7 @@ const TagsInputRoot = forwardRef<HTMLSpanElement, TagsInputRootProps>(
                 e.code === 'Enter' &&
                   ((e.target as HTMLInputElement).value = '');
                 e.code === 'Backspace' &&
+                  (e.target as HTMLInputElement).value === '' &&
                   selected.length !== 0 &&
                   onClear &&
                   onClear(selected.length - 1);


### PR DESCRIPTION
## Screenshot and description

* `TagsInput` now removes the last item if the user presses Backspace. It is a little more intuitive to delete tags with this feature.

## Checklist

- [x] You attached screenshots or added description about changes
- [x] You use [conventional commits naming](https://www.conventionalcommits.org/en/v1.0.0/), e.g. `fix: your changes description [TicketNumber]`, `feat: your feature name [TicketNumber]`
- [x] You have updated the documentation accordingly.
