### PR TITLE
feat: MDS-1000 add role prop for Popover.Trigger

### DIFF
--- a/workspaces/core/src/popover/Popover.tsx
+++ b/workspaces/core/src/popover/Popover.tsx
@@ -77,13 +77,20 @@ const PopoverRoot = ({
   );
 };
 
-const Trigger = ({ children, ...rest }: { children?: React.ReactNode }) => {
+const Trigger = ({
+  children,
+  role = 'button',
+  ...rest
+}: {
+  children?: React.ReactNode;
+  role?: string;
+}) => {
   const { popper } = usePopoverContext('Popover.Trigger');
   return (
     <HeadlessPopover.Button
       as={'div'}
       ref={popper?.setAnchor}
-      role="button"
+      role={role}
       {...rest}
     >
       {children}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

Role attribute for subcomponent Popover.Trigger is hardcoded as 'button'. In rare cases, it is necessary to change this attribute from outside. 

For this, we need to add 'role' props for the subcomponent Popover.Trigger 

<!---
  Describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask.
  We're here to help!
-->

- [ ] You attached screenshots or added description about changes
- [x] You use [conventional commits naming](https://www.conventionalcommits.org/en/v1.0.0/), e.g. `fix: your changes description [TicketNumber]`, `feat: your feature name [TicketNumber]`
- [ ] You have updated the documentation accordingly.
